### PR TITLE
 Send heart beat when woken up by tick

### DIFF
--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -152,6 +152,9 @@ func (npc *NetworkPolicyController) Run(healthChan chan<- *healthcheck.Controlle
 			glog.Infof("Shutting down network policies controller")
 			return
 		case <-t.C:
+			if err != nil {
+				healthcheck.SendHeartBeat(healthChan, "NPC")
+			}
 		}
 	}
 }

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -152,7 +152,7 @@ func (npc *NetworkPolicyController) Run(healthChan chan<- *healthcheck.Controlle
 			glog.Infof("Shutting down network policies controller")
 			return
 		case <-t.C:
-			if err != nil {
+			if err == nil {
 				healthcheck.SendHeartBeat(healthChan, "NPC")
 			}
 		}

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -321,6 +321,9 @@ func (nsc *NetworkServicesController) Run(healthChan chan<- *healthcheck.Control
 			glog.Info("Shutting down network services controller")
 			return nil
 		case <-t.C:
+			if err != nil {
+				healthcheck.SendHeartBeat(healthChan, "NSC")
+			}
 		}
 	}
 }

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -321,7 +321,7 @@ func (nsc *NetworkServicesController) Run(healthChan chan<- *healthcheck.Control
 			glog.Info("Shutting down network services controller")
 			return nil
 		case <-t.C:
-			if err != nil {
+			if err == nil {
 				healthcheck.SendHeartBeat(healthChan, "NSC")
 			}
 		}

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -293,6 +293,9 @@ func (nrc *NetworkRoutingController) Run(healthChan chan<- *healthcheck.Controll
 			glog.Infof("Shutting down network routes controller")
 			return
 		case <-t.C:
+			if err != nil {
+				healthcheck.SendHeartBeat(healthChan, "NRC")
+			}
 		}
 	}
 }

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -293,7 +293,7 @@ func (nrc *NetworkRoutingController) Run(healthChan chan<- *healthcheck.Controll
 			glog.Infof("Shutting down network routes controller")
 			return
 		case <-t.C:
-			if err != nil {
+			if err == nil {
 				healthcheck.SendHeartBeat(healthChan, "NRC")
 			}
 		}


### PR DESCRIPTION
Send heart beat when woken up by tick in case there were no errors during previous run.
This will ensure that we don't shut down controller just because it is slower during current run as compared to the previous run which has sent the last heart beat.
This way controller fails the health check only if it exceeds the cycle + grace period or it has failed during the previous run and current run either failed again or didn't finish yet